### PR TITLE
Escape Backslashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ If you are using [nix](https://zero-to-nix.com/start/install/) & [direnv](https:
 - [git](https://git-scm.com/)
 - [pyenv](https://github.com/pyenv/pyenv#installation)
 
+> Additionally, if you aren't using nix, then you will need to manually build
+> the "external" tools found in `external`. These are used during testing to
+> verify compatibility with libraries from different ecosystems. Alternatively, you can exclude those tests with `pytest -m "not external"`, but this is not recommended.
+
 ## Getting Started
 
 **Setup**

--- a/external/golang-logfmt-echo/default.nix
+++ b/external/golang-logfmt-echo/default.nix
@@ -1,0 +1,11 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+
+with pkgs;
+buildGoModule {
+  pname = "golang-logfmt-echo";
+  version = "0.0.0";
+  src = ./.;
+  vendorHash = "sha256-Yr+8wpleQTFxCYCCihhU5cyIuo11/66MaGgin2P924I=";
+}

--- a/external/golang-logfmt-echo/go.mod
+++ b/external/golang-logfmt-echo/go.mod
@@ -1,0 +1,5 @@
+module golang-logfmt-echo
+
+go 1.23
+
+require github.com/go-logfmt/logfmt v0.6.0

--- a/external/golang-logfmt-echo/go.sum
+++ b/external/golang-logfmt-echo/go.sum
@@ -1,0 +1,2 @@
+github.com/go-logfmt/logfmt v0.6.0 h1:wGYYu3uicYdqXVgoYbvnkrPVXkuLM1p1ifugDMEdRi4=
+github.com/go-logfmt/logfmt v0.6.0/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=

--- a/external/golang-logfmt-echo/main.go
+++ b/external/golang-logfmt-echo/main.go
@@ -1,0 +1,44 @@
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-logfmt/logfmt"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		decoder := logfmt.NewDecoder(strings.NewReader(line))
+
+		var pairs [][2]string
+
+		for decoder.ScanRecord() {
+			for decoder.ScanKeyval() {
+				key := string(decoder.Key())
+				val := string(decoder.Value())
+				pairs = append(pairs, [2]string{key, val})
+			}
+			if err := decoder.Err(); err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+				os.Exit(1)
+			}
+		}
+
+		var buf bytes.Buffer
+		encoder := logfmt.NewEncoder(&buf)
+		for _, kv := range pairs {
+			_ = encoder.EncodeKeyval(kv[0], kv[1])
+		}
+		_ = encoder.EndRecord()
+
+		fmt.Print(buf.String())
+	}
+}

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,14 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: {
+              golang-logfmt-echo = prev.callPackage ./external/golang-logfmt-echo { };
+            })
+          ];
+        };
       in
       {
         devShells.default = pkgs.mkShell {
@@ -19,6 +26,9 @@
             pkgs.python311
             pkgs.python312
             pkgs.python313
+
+            # external
+            pkgs.golang-logfmt-echo
           ];
           shellHook = "unset PYTHONPATH";
         };

--- a/src/logfmter/formatter.py
+++ b/src/logfmter/formatter.py
@@ -45,7 +45,11 @@ class Logfmter(logging.Formatter):
         """
         needs_dquote_escaping = '"' in value
         needs_newline_escaping = "\n" in value
-        needs_quoting = " " in value or "=" in value
+        needs_quoting = " " in value or "=" in value or needs_dquote_escaping
+        needs_backslash_escaping = "\\" in value and needs_quoting
+
+        if needs_backslash_escaping:
+            value = value.replace("\\", "\\\\")
 
         if needs_dquote_escaping:
             value = value.replace('"', '\\"')
@@ -56,7 +60,7 @@ class Logfmter(logging.Formatter):
         if needs_quoting:
             value = '"{}"'.format(value)
 
-        return value if value else '""'
+        return value if value else ""
 
     @classmethod
     def format_value(cls, value) -> str:


### PR DESCRIPTION
**Description**

Fix backslash escaping and verify compatibility with [go-logfmt/logfmt](https://github.com/go-logfmt/logfmt) which is used by tools such as Grafana/Loki.

**Testing Notes**

The new external tools compatibility tests require that the tools in `./external` are built and on `PATH`. The only tool being used currently is "golang-logfmt-echo" which simply wraps [go-logfmt/logfmt](https://github.com/go-logfmt/logfmt), a popular logfmt library used by Grafana. This tool is built automatically with Nix. If you aren't using Nix, you will need to build it manually or skip this test with `pytest -m "not external"`.

**Issues**
Resolves #15

**References**
- [structlog logfmt discussion](https://github.com/hynek/structlog/issues/511#issuecomment-1916481330)